### PR TITLE
Remove standard margin & add font fallback

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,10 @@
  body {
+    margin: 0;
     background-image: url('bg-1.webp');
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-size: cover;
-    font-family: "Helvetica";
+    font-family: "Helvetica", sans-serif;
   }
 
   .link {


### PR DESCRIPTION
HTML creates a standard margin on the body element which can make the sides of the website blank which is ugly to be honest. I also added a font fallback in case people don't have "Helvetica" installed (for some reason) so that it get's the font turns into their system default (sans-serif) font (for example Arial).